### PR TITLE
Fix header keyword rules and link clicks

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ This project provides a simple desktop wiki for managing RPG campaigns and world
 ## Features
 - Load separate world and campaign directories of Markdown files.
 - Automatically build a keyword map from Markdown headers using special rules.
+  A header must contain a symbol such as `!`, `*`, `foo/s` or `/` to create
+  keywords. Plain headers without symbols are ignored.
 - Clickable links inside the text area jump to linked files and sections.
 - Persistent configuration for recently loaded folders and case sensitivity.
 

--- a/rpgwiki/gui.py
+++ b/rpgwiki/gui.py
@@ -156,7 +156,8 @@ class WikiApp(tk.Tk):
         index = self.text.index("@%d,%d" % (event.x, event.y))
         for tag in self.text.tag_names(index):
             if tag == 'link':
-                word = self.text.get(index, f"{index} wordend")
+                start, end = self.text.tag_prevrange('link', index + '+1c')
+                word = self.text.get(start, end)
                 target = self.keyword_map.get(word)
                 if not target and not self.config_data.case_sensitive:
                     lower = word.lower()


### PR DESCRIPTION
## Summary
- refine README around header symbols for keywords
- only treat headers with special symbols as keywords
- fix link lookup to pull text from the tagged region

## Testing
- `python -m py_compile rpgwiki/parser.py rpgwiki/gui.py`
- `python main.py` *(fails: no display)*

------
https://chatgpt.com/codex/tasks/task_e_685070a9bab08325b63d2c9c53d728ca