### PR TITLE
Improve navigation display and add button logging

### DIFF
--- a/rpgwiki/parser.py
+++ b/rpgwiki/parser.py
@@ -77,7 +77,7 @@ def scan_folder(folder: str) -> Dict[str, KeywordTarget]:
     keyword_map: Dict[str, KeywordTarget] = {}
     for root, _, files in os.walk(folder):
         for f in files:
-            if not f.lower().endswith('.md'):
+            if not f.lower().endswith('.md') or f.startswith('_'):
                 continue
             path = os.path.join(root, f)
             with open(path, 'r', encoding='utf-8', errors='ignore') as fp:


### PR DESCRIPTION
## Summary
- show sub-directories only when they contain markdown files
- filter out underscore-prefixed markdown files
- list sub-directories before files and drop `.md` from names
- log which navigation buttons are bound and pressed

## Testing
- `python -m py_compile rpgwiki/*.py`
- `python main.py` *(fails: no display)*

------
https://chatgpt.com/codex/tasks/task_e_685075181f3c8325bc156d6b245a085d