### PR TITLE
Improve header navigation

### DIFF
--- a/rpgwiki/formatter.py
+++ b/rpgwiki/formatter.py
@@ -48,13 +48,17 @@ def format_content(content: str, keyword_map: Dict[str, KeywordTarget], config: 
     """Convert raw wiki text to HTML with links, wrapping and header styles."""
     keywords = sorted(keyword_map.keys(), key=len, reverse=True)
     lines_html: List[str] = []
-    for line in content.splitlines():
+    for lineno, line in enumerate(content.splitlines(), 1):
         stripped = line.lstrip()
         if stripped.startswith("#"):
             level = len(stripped) - len(stripped.lstrip("#"))
             text, _ = parse_header(line)
             size = HEADER_SIZES.get(level, 12)
-            line_html = f'<span style="font-size:{size}px; font-weight:bold">{escape(text)}</span>'
+            anchor = f"ln{lineno}"
+            line_html = (
+                f'<span id="{anchor}" style="font-size:{size}px; font-weight:bold">'
+                f"{escape(text)}</span>"
+            )
         else:
             line_html = _apply_links_to_line(line, keywords, config.case_sensitive)
         lines_html.append(line_html)

--- a/rpgwiki/gui.py
+++ b/rpgwiki/gui.py
@@ -3,7 +3,7 @@ import sys
 from typing import Dict
 
 from PyQt5.QtCore import Qt, QEvent, QUrl
-from PyQt5.QtGui import QTextCursor
+
 from PyQt5.QtWidgets import (
     QApplication,
     QMainWindow,
@@ -246,11 +246,8 @@ class WikiApp(QMainWindow):
                     break
         if target:
             self.open_file(target.file)
-            block = self.text.document().findBlockByLineNumber(target.line - 1)
-            cursor = QTextCursor(block)
-            self.text.setTextCursor(cursor)
-            bar = self.text.verticalScrollBar()
-            bar.setValue(self.text.cursorRect(cursor).top())
+            anchor = f"ln{target.line}"
+            self.text.scrollToAnchor(anchor)
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- add per-line anchors in formatter
- remove unused import
- use QTextBrowser.scrollToAnchor for navigation

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68507f2aade48325b24877c394f5af1b