### PR TITLE
Add search page access

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ This project provides a simple desktop wiki for managing RPG campaigns and world
   keywords. Plain headers without symbols are ignored.
 - Clickable links inside the text area jump to linked files and sections.
 - Persistent configuration for recently loaded folders and case sensitivity.
+- Search headers via `File -> Search` or by pressing <kbd>Space</kbd> or
+  <kbd>Up</kbd> during normal use.
 
 ## Running
 Install Python 3.11+ and `PyQt5` then run the application with:

--- a/rpgwiki/gui.py
+++ b/rpgwiki/gui.py
@@ -86,6 +86,10 @@ class WikiApp(QMainWindow):
         rescan_action.triggered.connect(self.rescan)
         file_menu.addAction(rescan_action)
 
+        search_action = QAction("Search", self)
+        search_action.triggered.connect(self.show_search)
+        file_menu.addAction(search_action)
+
         file_menu.addSeparator()
 
         exit_action = QAction("Exit", self)


### PR DESCRIPTION
## Summary
- add a `Search` option to the File menu so the search dialog can be opened via the menu
- document the new menu item and hotkeys

## Testing
- `python -m py_compile main.py rpgwiki/*.py`

------
https://chatgpt.com/codex/tasks/task_e_685084cc240c8325939ebd04d6151ab6