### PR TITLE
Improve search shortcuts and previews

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This project provides a simple desktop wiki for managing RPG campaigns and world
   keywords. Plain headers without symbols are ignored.
 - Clickable links inside the text area jump to linked files and sections.
 - Persistent configuration for recently loaded folders and case sensitivity.
-- Search headers via `File -> Search` or by pressing <kbd>Space</kbd> or
+- Search headers via `File -> Search` or by pressing <kbd>Tab</kbd> or
   <kbd>Up</kbd> during normal use.
 
 ## Running

--- a/rpgwiki/gui.py
+++ b/rpgwiki/gui.py
@@ -65,7 +65,7 @@ class WikiApp(QMainWindow):
             if event.key() == Qt.Key_Right:
                 self.go_forward()
                 return True
-            if event.key() in (Qt.Key_Space, Qt.Key_Up):
+            if event.key() in (Qt.Key_Tab, Qt.Key_Up):
                 if isinstance(obj, QLineEdit):
                     return False
                 self.show_search()

--- a/rpgwiki/parser.py
+++ b/rpgwiki/parser.py
@@ -115,13 +115,25 @@ def scan_headers(folder: str) -> List[HeaderEntry]:
             for lineno, line in enumerate(lines, 1):
                 if line.lstrip().startswith('#'):
                     text, _ = parse_header(line)
-                    snippet = ' '.join(l.strip() for l in lines[lineno:lineno + 3])
+                    after = ' '.join(l.strip() for l in lines[lineno:])
+                    after = ' '.join(after.split())
+                    if len(after) <= 160:
+                        preview = after
+                    else:
+                        end = after.find('.', 160)
+                        if end == -1 or end > 220:
+                            end = 220
+                            preview = after[:end].rstrip()
+                            if len(after) > end:
+                                preview += '...'
+                        else:
+                            preview = after[: end + 1]
                     headers.append(
                         HeaderEntry(
                             file=path,
                             line=lineno,
                             text=text,
-                            preview=snippet[:120],
+                            preview=preview,
                         )
                     )
     return headers

--- a/rpgwiki/search.py
+++ b/rpgwiki/search.py
@@ -57,10 +57,14 @@ class SearchPage(QWidget):
         self.results = full + partial
         lines: List[str] = []
         for idx, item in enumerate(self.results[:9], 1):
+            filename = item.file.split("/")[-1]
             line = (
                 f"<p><a href='{idx-1}' style='text-decoration:none'>"
-                f"<span style='background-color:#eef; padding:1px 4px; border-radius:3px'>"
-                f"{item.file.split('/')[-1]}</span> <b>{item.text}</b></a> - {item.preview}</p>"
+                f"<span style='float:right; background-color:#eef; padding:1px 4px; border-radius:3px'>"
+                f"{filename}</span>"
+                f"<span style='font-size:18px; font-weight:bold'>{item.text}</span>" 
+                f"</a><br>"
+                f"<span style='font-size:12px'>{item.preview}</span></p>"
             )
             lines.append(line)
         self.browser.setHtml("\n".join(lines))


### PR DESCRIPTION
## Summary
- update keyboard shortcut to open search (Tab instead of Space)
- right-align file names in search results and enlarge fonts
- extend preview snippets to 160-220 characters with sentence end detection
- update README with new shortcut

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68508cc95e808325907fd015924f3c31