### PR TITLE
Update search results layout

### DIFF
--- a/rpgwiki/search.py
+++ b/rpgwiki/search.py
@@ -59,11 +59,13 @@ class SearchPage(QWidget):
         for idx, item in enumerate(self.results[:9], 1):
             filename = item.file.split("/")[-1]
             line = (
-                f"<p><a href='{idx-1}' style='display:block; text-decoration:none; position:relative'>"
+                f"<p>"
+                f"<a href='{idx-1}' style='text-decoration:none'>"
                 f"<span style='font-size:18px; font-weight:bold'>{item.text}</span>"
-                f"<span style='position:absolute; right:0; background-color:#eef; padding:1px 4px; border-radius:3px'>{filename}</span>"
                 f"</a><br>"
-                f"<span style='font-size:12px'>{item.preview}</span></p>"
+                f"<span style='font-size:12px'>{item.preview}</span><br>"
+                f"<span style='display:block; text-align:right; background-color:#eef; padding:1px 4px; border-radius:3px'>{filename}</span>"
+                f"</p>"
             )
             lines.append(line)
         self.browser.setHtml("\n".join(lines))


### PR DESCRIPTION
## Summary
- move filename below description in search results so it's right-aligned

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6850908683ec8325b6deeaf3d9870dc6